### PR TITLE
Fix when line number is greater than last line

### DIFF
--- a/lua/fileline.lua
+++ b/lua/fileline.lua
@@ -9,7 +9,7 @@ local function reopen_and_gotoline(file_name, lnum, col)
   vim.cmd.edit{vim.fn.fnameescape(file_name), mods = { keepalt = true }}
 
   vim.api.nvim_buf_delete(bufn, {})
-
+  lnum = math.min(lnum, vim.api.nvim_buf_line_count(0))
   vim.api.nvim_win_set_cursor(0, { lnum, col and col - 1 or 0 })
 
   if vim.fn.foldlevel(lnum) > 0 then


### PR DESCRIPTION
When I have a file

    wc -l file.test
    4

and open it with

   nvim file.test:5

the plugin throws an error.

The behavior of the plugin has been changed to only take the given line number if it is smaler or equal to the number of lines in the file. So running `nvim file.test:5` with this patch sets the cursor to line 4.