### PR TITLE
fix: support a line number of 0, which is natively supported by *Neovim*

### DIFF
--- a/lua/fileline.lua
+++ b/lua/fileline.lua
@@ -14,7 +14,7 @@ local function reopen_and_gotoline(file_name, lnum, col)
     vim.api.nvim_buf_delete(bufn, {})
   end)
 
-  lnum = math.min(lnum, vim.api.nvim_buf_line_count(0))
+  lnum = math.min(math.max(1, lnum), vim.api.nvim_buf_line_count(0))
   vim.api.nvim_win_set_cursor(0, { lnum, col and col - 1 or 0 })
 
   if vim.fn.foldlevel(lnum) > 0 then


### PR DESCRIPTION
The use case here is *Broot*. It uses a line number of 0 when a file isn't opened from its right file viewer pane.

This also works in *Neovim*:

    $ nvim +0 /tmp/foo.txt